### PR TITLE
fedora: add sops + age + direnv secrets tooling

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -7,16 +7,16 @@ URL, module path, or package name).
 
 ## Fedora
 
-- **`sops` is not packaged for Fedora** (`dnf list sops` → nothing), so it's
-  installed via `go install github.com/getsops/sops/v3/cmd/sops@latest` (note the
-  `getsops` org and `/v3` — the project moved from Mozilla to the `getsops` org).
-  `age` and `direnv` *are* in the Fedora repos, so those go in `pkglist.txt`.
+- **Secrets workflow is 1Password (`op` CLI)** — not bw/sops/age (dropped
+  2026-06-19 after a work-provided free 1Password Family plan became available).
+  `op` has a native rpm: install from 1Password's official dnf repo
+  (`downloads.1password.com/linux/rpm/stable`), not via `go`/`npm`. The workflow
+  is `op run --env-file=.env` + `op://vault/item/field` references — no local key
+  material to back up (unlike the old sops/age age-key).
 - **direnv needs a shell hook** to work: `eval "$(direnv hook zsh)"` in `.zshrc`.
-  It's placed in `config/shell/.zshrc` *before* the zoxide init (zoxide's doctor
-  insists on being initialized last).
-- **age key location:** sops auto-discovers `~/.config/sops/age/keys.txt` on Linux
-  (XDG default) — no `SOPS_AGE_KEY_FILE` export needed. The config script
-  generates one if absent. This key is unrecoverable if lost; back it up.
+  It's packaged in the Fedora repos (in `pkglist.txt`) and the hook lives in
+  `config/shell/.zshrc` *before* the zoxide init (zoxide's doctor insists on being
+  initialized last). Pairs with `op run` for per-project env loading.
 
 - **obsidian-cli was renamed to `notesmd-cli`** (2026-06). The upstream module
   `github.com/Yakitrak/obsidian-cli` now declares its path as

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -7,6 +7,17 @@ URL, module path, or package name).
 
 ## Fedora
 
+- **`sops` is not packaged for Fedora** (`dnf list sops` → nothing), so it's
+  installed via `go install github.com/getsops/sops/v3/cmd/sops@latest` (note the
+  `getsops` org and `/v3` — the project moved from Mozilla to the `getsops` org).
+  `age` and `direnv` *are* in the Fedora repos, so those go in `pkglist.txt`.
+- **direnv needs a shell hook** to work: `eval "$(direnv hook zsh)"` in `.zshrc`.
+  It's placed in `config/shell/.zshrc` *before* the zoxide init (zoxide's doctor
+  insists on being initialized last).
+- **age key location:** sops auto-discovers `~/.config/sops/age/keys.txt` on Linux
+  (XDG default) — no `SOPS_AGE_KEY_FILE` export needed. The config script
+  generates one if absent. This key is unrecoverable if lost; back it up.
+
 - **obsidian-cli was renamed to `notesmd-cli`** (2026-06). The upstream module
   `github.com/Yakitrak/obsidian-cli` now declares its path as
   `github.com/Yakitrak/notesmd-cli`, so `go install …/obsidian-cli@latest` fails

--- a/config/shell/.zshrc
+++ b/config/shell/.zshrc
@@ -153,4 +153,7 @@ export PATH="$PATH:$HOME/.local/bin"
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
+command -v direnv >/dev/null && eval "$(direnv hook zsh)"
+
+# keep zoxide init last (see its doctor warning)
 eval "$(zoxide init zsh)"

--- a/linux/fedora/config-shell-tools-fedora.sh
+++ b/linux/fedora/config-shell-tools-fedora.sh
@@ -72,3 +72,15 @@ if [ -x "$HOME/go/bin/notesmd-cli" ]; then
 fi
 # Bitwarden CLI — no maintained native rpm, install via npm (Node already set up)
 command -v bw >/dev/null || npm install -g @bitwarden/cli >/dev/null
+
+step "Secrets tooling (sops + age + direnv)"
+# age + direnv come from pkglist (dnf). sops has no Fedora package — install via
+# go (already present). Binary lands in ~/go/bin as `sops`.
+[ -x "$HOME/go/bin/sops" ] || go install github.com/getsops/sops/v3/cmd/sops@latest
+# Generate a personal age key for sops if none exists (sops auto-discovers it here).
+if [ ! -f "$HOME/.config/sops/age/keys.txt" ] && command -v age-keygen >/dev/null; then
+  mkdir -p "$HOME/.config/sops/age"
+  age-keygen -o "$HOME/.config/sops/age/keys.txt"
+  chmod 600 "$HOME/.config/sops/age/keys.txt"
+  echo "  age key created — BACK UP ~/.config/sops/age/keys.txt (lose it = lose all sops-encrypted files)"
+fi

--- a/linux/fedora/config-shell-tools-fedora.sh
+++ b/linux/fedora/config-shell-tools-fedora.sh
@@ -50,7 +50,7 @@ if ! command -v yazi >/dev/null; then
   rm -rf /tmp/yazi.zip /tmp/yazi-x86_64-unknown-linux-gnu
 fi
 
-step "Obsidian + obsidian-cli, gh, Bitwarden CLI"
+step "Obsidian + obsidian-cli, gh"
 # gh installed via pkglist (dnf). Obsidian has no native rpm — use Flatpak
 # (preinstalled on Fedora Workstation/KDE).
 if command -v flatpak >/dev/null; then
@@ -70,17 +70,13 @@ if [ -x "$HOME/go/bin/notesmd-cli" ]; then
   mkdir -p "$HOME/.zsh_functions"
   "$HOME/go/bin/notesmd-cli" completion zsh > "$HOME/.zsh_functions/_notesmd-cli"
 fi
-# Bitwarden CLI — no maintained native rpm, install via npm (Node already set up)
-command -v bw >/dev/null || npm install -g @bitwarden/cli >/dev/null
-
-step "Secrets tooling (sops + age + direnv)"
-# age + direnv come from pkglist (dnf). sops has no Fedora package — install via
-# go (already present). Binary lands in ~/go/bin as `sops`.
-[ -x "$HOME/go/bin/sops" ] || go install github.com/getsops/sops/v3/cmd/sops@latest
-# Generate a personal age key for sops if none exists (sops auto-discovers it here).
-if [ ! -f "$HOME/.config/sops/age/keys.txt" ] && command -v age-keygen >/dev/null; then
-  mkdir -p "$HOME/.config/sops/age"
-  age-keygen -o "$HOME/.config/sops/age/keys.txt"
-  chmod 600 "$HOME/.config/sops/age/keys.txt"
-  echo "  age key created — BACK UP ~/.config/sops/age/keys.txt (lose it = lose all sops-encrypted files)"
+step "1Password CLI (op)"
+# Secrets workflow is 1Password-based: op run / op:// references (no local key
+# material). Install from 1Password's official dnf repo (has a native rpm).
+# direnv (from pkglist) pairs with `op run` for per-project env loading.
+if ! command -v op >/dev/null; then
+  sudo rpm --import https://downloads.1password.com/linux/keys/1password.asc
+  sudo sh -c 'echo -e "[1password]\nname=1Password Stable Channel\nbaseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=\"https://downloads.1password.com/linux/keys/1password.asc\"" > /etc/yum.repos.d/1password.repo'
+  sudo dnf install -q -y 1password-cli
 fi
+echo "  Sign in with: eval \"\$(op signin)\"  (or enable desktop-app CLI integration for biometric unlock)"

--- a/linux/fedora/pkglist.txt
+++ b/linux/fedora/pkglist.txt
@@ -13,6 +13,10 @@ jq
 zsh
 vim-enhanced
 tmux
+direnv
+
+# Secrets (sops is not packaged for Fedora — installed via go in config script)
+age
 
 # Dev tools
 cmake

--- a/linux/fedora/pkglist.txt
+++ b/linux/fedora/pkglist.txt
@@ -15,9 +15,6 @@ vim-enhanced
 tmux
 direnv
 
-# Secrets (sops is not packaged for Fedora — installed via go in config script)
-age
-
 # Dev tools
 cmake
 luarocks


### PR DESCRIPTION
age and direnv ship in the Fedora repos (added to pkglist). sops has no Fedora package, so install it via go (github.com/getsops/sops/v3) in the config script, which also generates a personal age key at ~/.config/sops/age/keys.txt if absent. Wire the direnv shell hook into config/shell/.zshrc (before zoxide init, which must stay last). Record the gotchas in LEARNINGS.md.