### PR TITLE
fix(shell): silence zoxide doctor false-positive in non-interactive shells

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -17,6 +17,11 @@ URL, module path, or package name).
   It's packaged in the Fedora repos (in `pkglist.txt`) and the hook lives in
   `config/shell/.zshrc` *before* the zoxide init (zoxide's doctor insists on being
   initialized last). Pairs with `op run` for per-project env loading.
+- **zoxide doctor false-positives in non-interactive shells** (AI-agent/tool
+  shells, scripts) even when init *is* last — precmd hooks never register there,
+  and the warning pollutes every command's output (burns AI context tokens).
+  `export _ZO_DOCTOR=0` before the init line silences it; interactive behavior
+  is unaffected.
 
 - **obsidian-cli was renamed to `notesmd-cli`** (2026-06). The upstream module
   `github.com/Yakitrak/obsidian-cli` now declares its path as

--- a/config/shell/.zshrc
+++ b/config/shell/.zshrc
@@ -155,5 +155,8 @@ export PATH="$PATH:$HOME/.local/bin"
 
 command -v direnv >/dev/null && eval "$(direnv hook zsh)"
 
-# keep zoxide init last (see its doctor warning)
+# keep zoxide init last (see its doctor warning). _ZO_DOCTOR=0 because the
+# doctor false-positives in non-interactive shells (e.g. AI-agent/tool shells,
+# where precmd hooks never register) and spams every command's output.
+export _ZO_DOCTOR=0
 eval "$(zoxide init zsh)"


### PR DESCRIPTION
The zoxide doctor warning fires in non-interactive shells (AI-agent/tool shells, scripts) even though init is correctly last in .zshrc — precmd hooks never register there. It polluted every command's output in Claude Code sessions (wasted context tokens on each call).

Fix: `export _ZO_DOCTOR=0` before the init line. Interactive behavior unchanged. LEARNINGS entry added.

Verified: tool-shell output is clean after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)