### PR TITLE
feat(fedora): obsidian vault encrypted backup (rclone crypt → Drive)

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -36,3 +36,11 @@ run '~/.tmux/plugins/tpm/tpm'
 
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
+
+## Obsidian vault: encrypted backup & restore
+# Daily encrypted backup (rclone crypt → Google Drive) is installed by
+# linux/fedora/config-shell-tools-fedora.sh (script: config/backup/vault-backup.sh,
+# units: config/systemd/vault-backup.{service,timer}).
+# RESTORE on a new machine: open the 1Password item "obsidian-vault-backup" —
+# its notes contain the full step-by-step guide (keys are its password/salt fields).
+# After restore: systemctl --user enable --now vault-backup.timer

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -22,6 +22,23 @@ URL, module path, or package name).
   and the warning pollutes every command's output (burns AI context tokens).
   `export _ZO_DOCTOR=0` before the init line silences it; interactive behavior
   is unaffected.
+- **1Password desktop-app CLI integration only accepts the system `op`** — it
+  validates root ownership + setgid `onepassword-cli` (`-rwxr-sr-x root
+  onepassword-cli /usr/bin/op`). A user-local copy (`~/.local/bin/op`) fails with
+  the misleading `connecting to desktop app: read: connection reset`, and it also
+  makes a `command -v op` install-guard skip the system package — guard on
+  `rpm -q 1password-cli` instead, and warn about stray user copies (they shadow
+  the system binary in PATHs that put `~/.local/bin` first, e.g. systemd units).
+- **rclone connection-string colon trap**: in an inline remote like
+  `:crypt,remote=gdrive:path:` the parser cuts the option value at the first
+  `:`, so `remote=gdrive` resolves to a **local `./gdrive` directory**
+  (cwd-relative) and the "backup" silently never leaves the machine. Always
+  define a named crypt remote (`rclone config create gdrive-crypt crypt
+  remote=gdrive:path`) and target `gdrive-crypt:`. Crypt passwords don't need to
+  live in the config — `RCLONE_CRYPT_PASSWORD(_2)` env vars (obscured) act as
+  defaults, which is how `config/backup/vault-backup.sh` injects them from
+  1Password. Vault restore guide lives in the 1Password item
+  `obsidian-vault-backup`.
 
 - **obsidian-cli was renamed to `notesmd-cli`** (2026-06). The upstream module
   `github.com/Yakitrak/obsidian-cli` now declares its path as

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -17,6 +17,11 @@ URL, module path, or package name).
   It's packaged in the Fedora repos (in `pkglist.txt`) and the hook lives in
   `config/shell/.zshrc` *before* the zoxide init (zoxide's doctor insists on being
   initialized last). Pairs with `op run` for per-project env loading.
+- **zoxide doctor false-positives in non-interactive shells** (AI-agent/tool
+  shells, scripts) even when init *is* last — precmd hooks never register there,
+  and the warning pollutes every command's output (burns AI context tokens).
+  `export _ZO_DOCTOR=0` before the init line silences it; interactive behavior
+  is unaffected.
 
 - **obsidian-cli was renamed to `notesmd-cli`** (2026-06). The upstream module
   `github.com/Yakitrak/obsidian-cli` now declares its path as

--- a/config/backup/vault-backup.sh
+++ b/config/backup/vault-backup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Encrypted Obsidian vault backup: ~/Documents/obsidian → Google Drive (rclone crypt).
+# Client-side encrypted — Google only ever stores ciphertext (contents + filenames).
+# Crypt password + salt live in 1Password (op read) — no secret material on disk.
+# See vault note: docs/system/vault-backup-rclone.md
+set -euo pipefail
+
+VAULT="$HOME/Documents/obsidian"
+OP_ITEM="op://Private/obsidian-vault-backup"
+
+RCLONE_CRYPT_PASSWORD="$(rclone obscure "$(op read "$OP_ITEM/password")")"
+RCLONE_CRYPT_PASSWORD2="$(rclone obscure "$(op read "$OP_ITEM/salt")")"
+export RCLONE_CRYPT_PASSWORD RCLONE_CRYPT_PASSWORD2
+
+# .git included on purpose (history is part of the backup).
+# Deletions go to Drive trash (rclone default) — extra safety net.
+# NB: target is the named [gdrive-crypt] config remote, NOT an inline
+# ":crypt,remote=gdrive:path:" string — the connection-string parser cuts the
+# value at the first ":", silently turning the target into a LOCAL ./gdrive dir.
+exec rclone sync "$VAULT" "gdrive-crypt:" \
+  --exclude ".obsidian/workspace*" \
+  --create-empty-src-dirs \
+  --fast-list \
+  --log-level NOTICE

--- a/config/shell/.zshrc
+++ b/config/shell/.zshrc
@@ -155,5 +155,8 @@ export PATH="$PATH:$HOME/.local/bin"
 
 command -v direnv >/dev/null && eval "$(direnv hook zsh)"
 
-# keep zoxide init last (see its doctor warning)
+# keep zoxide init last (see its doctor warning). _ZO_DOCTOR=0 because the
+# doctor false-positives in non-interactive shells (e.g. AI-agent/tool shells,
+# where precmd hooks never register) and spams every command's output.
+export _ZO_DOCTOR=0
 eval "$(zoxide init zsh)"

--- a/config/systemd/vault-backup.service
+++ b/config/systemd/vault-backup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Encrypted Obsidian vault backup to Google Drive (rclone crypt)
+
+[Service]
+Type=oneshot
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin
+ExecStart=%h/.local/bin/vault-backup.sh

--- a/config/systemd/vault-backup.timer
+++ b/config/systemd/vault-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily encrypted Obsidian vault backup
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/linux/fedora/config-shell-tools-fedora.sh
+++ b/linux/fedora/config-shell-tools-fedora.sh
@@ -74,9 +74,28 @@ step "1Password CLI (op)"
 # Secrets workflow is 1Password-based: op run / op:// references (no local key
 # material). Install from 1Password's official dnf repo (has a native rpm).
 # direnv (from pkglist) pairs with `op run` for per-project env loading.
-if ! command -v op >/dev/null; then
+# NB: guard on the rpm, NOT `command -v op` — a stray user-local op (e.g.
+# ~/.local/bin/op) would pass the check, but desktop-app integration only
+# accepts the system binary (root:onepassword-cli, setgid). See LEARNINGS.md.
+if ! rpm -q 1password-cli >/dev/null 2>&1; then
   sudo rpm --import https://downloads.1password.com/linux/keys/1password.asc
   sudo sh -c 'echo -e "[1password]\nname=1Password Stable Channel\nbaseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=\"https://downloads.1password.com/linux/keys/1password.asc\"" > /etc/yum.repos.d/1password.repo'
   sudo dnf install -q -y 1password-cli
 fi
-echo "  Sign in with: eval \"\$(op signin)\"  (or enable desktop-app CLI integration for biometric unlock)"
+[ -e "$HOME/.local/bin/op" ] && echo "  WARNING: stray ~/.local/bin/op found — remove it (shadows the system op in some PATHs)"
+echo "  Enable app integration: 1Password app → Settings → Developer → 'Integrate with 1Password CLI'"
+
+step "Obsidian vault backup (rclone crypt → Google Drive)"
+# Encrypted daily backup of ~/Documents/obsidian. Crypt keys + the full restore
+# guide live in the 1Password item "obsidian-vault-backup" (Private vault).
+# On a NEW machine: restore the vault first (guide in that item), then enable
+# the timer. rclone comes from pkglist (Fedora repos).
+command -v rclone >/dev/null || sudo dnf install -q -y rclone
+install -D "$SCRIPT_DIR/../../config/backup/vault-backup.sh" "$HOME/.local/bin/vault-backup.sh"
+mkdir -p "$HOME/.config/systemd/user"
+cp "$SCRIPT_DIR/../../config/systemd/vault-backup.service" \
+   "$SCRIPT_DIR/../../config/systemd/vault-backup.timer" "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+echo "  Once per machine (interactive): follow the restore guide in the 1Password"
+echo "  item 'obsidian-vault-backup' (rclone gdrive OAuth + gdrive-crypt remote),"
+echo "  then: systemctl --user enable --now vault-backup.timer"

--- a/linux/fedora/pkglist.txt
+++ b/linux/fedora/pkglist.txt
@@ -29,6 +29,7 @@ zoxide
 
 # CLIs
 gh
+rclone
 
 # System info
 fastfetch


### PR DESCRIPTION
Adds the encrypted-vault-backup machinery to machine setup:

- **`config/backup/vault-backup.sh`** — daily client-side-encrypted backup of `~/Documents/obsidian` to Google Drive via the named `gdrive-crypt` rclone remote. Crypt password+salt are pulled from 1Password at runtime and injected via `RCLONE_CRYPT_PASSWORD(_2)` — no secret material on disk.
- **`config/systemd/vault-backup.{service,timer}`** — daily user timer (persistent, jittered).
- **Fedora tools script** installs both + `rclone` (now in pkglist). Interactive remainder (OAuth / restore) is documented in the 1Password item `obsidian-vault-backup`, whose notes now carry the full restore guide.
- **op install-guard fixed**: `command -v op` let a stray `~/.local/bin/op` skip the system package — but desktop-app integration validates root+setgid `onepassword-cli` and fails with a misleading "connection reset". Now guards on `rpm -q 1password-cli` and warns about stray copies.
- **LEARNINGS**: the above + the rclone connection-string colon trap (inline `:crypt,remote=gdrive:path:` silently writes to a local `./gdrive` dir).

Verified on this machine: first backup on Drive (101/101 objects, ciphertext-only), decode round-trip checked, timer enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)