### PR TITLE
feat: Antigravity tooling + Claude/agy config backups + shell fixes

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@pegasusheavy/google-mcp@1.0.2"
+      ]
+    }
+  }
+}

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -1,46 +1,81 @@
+# Manual setup actions
+
+One-off commands and snippets for steps that aren't (yet) automated by the
+setup scripts. Kept as a reference / scratchpad.
+
 ## Set up neovim
+
+```bash
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
 sudo rm -rf /opt/nvim-linux-x86_64
 sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
 export PATH="$PATH:/opt/nvim-linux-x86_64/bin"
+```
 
-## Set up lazyvim
+## Set up LazyVim
+
+```bash
+# Back up any existing config first
 mv ~/.config/nvim{,.bak}
 mv ~/.local/share/nvim{,.bak}
 mv ~/.local/state/nvim{,.bak}
 mv ~/.cache/nvim{,.bak}
-# Clone starter 
+
+# Clone starter
 git clone https://github.com/LazyVim/starter ~/.config/nvim
+```
 
 ## Set up clipboard
+
+```bash
 sudo apt update
 sudo apt install xclip
+```
 
-## Then make Neovim use system clipboard by adding to ~/.config/nvim/init.lua (or init.vim):
+Then make Neovim use the system clipboard by adding to
+`~/.config/nvim/init.lua`:
+
+```lua
 vim.opt.clipboard = "unnamedplus"
+```
 
-## Add to ~/.tmux.conf
+And add to `~/.tmux.conf`:
+
+```tmux
 set -g set-clipboard on
+```
 
-## Set up tmux persistance
+## Set up tmux persistence
+
+```bash
 git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+```
 
-Edit ~/.tmux.conf, add plugins
+Edit `~/.tmux.conf` and add the plugins:
+
+```tmux
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
-
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
-
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
 
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'
+```
+
 ## Obsidian vault: encrypted backup & restore
-# Daily encrypted backup (rclone crypt → Google Drive) is installed by
-# linux/fedora/config-shell-tools-fedora.sh (script: config/backup/vault-backup.sh,
-# units: config/systemd/vault-backup.{service,timer}).
-# RESTORE on a new machine: open the 1Password item "obsidian-vault-backup" —
-# its notes contain the full step-by-step guide (keys are its password/salt fields).
-# After restore: systemctl --user enable --now vault-backup.timer
+
+Daily encrypted backup (rclone crypt → Google Drive) is installed by
+`linux/fedora/config-shell-tools-fedora.sh` (script:
+`config/backup/vault-backup.sh`, units:
+`config/systemd/vault-backup.{service,timer}`).
+
+RESTORE on a new machine: open the 1Password item `obsidian-vault-backup` —
+its notes contain the full step-by-step guide (keys are its password/salt
+fields). After restore:
+
+```bash
+systemctl --user enable --now vault-backup.timer
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,33 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Repository Purpose
 
-This repository contains automated setup scripts and configuration files for quickly setting up development environments on new laptops or VMs across Linux (Arch, Ubuntu, Fedora) and Windows platforms.
+This repository contains automated setup scripts and configuration files for
+quickly setting up development environments on new laptops or VMs across Linux
+(Arch, Ubuntu, Fedora) and Windows platforms.
 
-> **Read [LEARNINGS.md](LEARNINGS.md) before modifying install logic** — it records non-obvious gotchas (upstream renames, broken pinned URLs, package quirks). Add an entry whenever a fix turns out to be non-obvious.
+> **Read [LEARNINGS.md](LEARNINGS.md) before modifying install logic** — it
+> records non-obvious gotchas (upstream renames, broken pinned URLs, package
+> quirks). Add an entry whenever a fix turns out to be non-obvious.
 
 ## Repository Structure
 
 The repository is organized by operating system:
 
 - `linux/arch/` - Arch Linux setup scripts and package list
-- `linux/ubuntu/` - Ubuntu setup scripts
-- `linux/fedora/` - Fedora setup scripts (`setup.sh` entry point → `install-zsh-fedora.sh`, `config-shell-tools-fedora.sh`) and `pkglist.txt`
+- `linux/ubuntu/` - Ubuntu setup scripts (`install-zsh-ubuntu.sh`,
+  `config-shell-tools-ubuntu.sh`, `setup-tmux.sh`) and `pkglist.txt`
+- `linux/fedora/` - Fedora setup scripts (`setup.sh` entry point →
+  `install-zsh-fedora.sh`, `config-shell-tools-fedora.sh`), optional
+  `install-infra-fedora.sh`, `check-dotfiles.sh` audit tool, and `pkglist.txt`
 - `windows/` - Windows PowerShell setup script
-- `config/shell/` - Shared shell configuration files (.zshrc, starship.toml)
+- `config/shell/` - Shared shell configuration files (`.zshrc`,
+  `starship.toml`, `.tmux.conf`)
+- `config/backup/` + `config/systemd/` - Encrypted Obsidian vault backup
+  (rclone crypt → Google Drive) script and systemd user units
 
 ## Script Architecture
 
@@ -24,55 +35,93 @@ The repository is organized by operating system:
 
 All Linux setup scripts follow a consistent architecture:
 
-1. **Dependency Checking**: Use `command -v` to check if tools are installed before attempting installation
-2. **Idempotent Installations**: Check for existing installations (e.g., `[ ! -d "$HOME/.oh-my-zsh" ]`) to avoid redundant operations
-3. **Configuration Path Resolution**: Use `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` to locate scripts, then reference shared config files via relative paths like `$SCRIPT_DIR/../../config/shell`
-4. **Silent Installation**: Use appropriate flags (`--noconfirm` for pacman, `-y` for apt) to avoid interactive prompts
+1. **Dependency Checking**: Use `command -v` to check if tools are installed
+   before attempting installation
+2. **Idempotent Installations**: Check for existing installations (e.g.,
+   `[ ! -d "$HOME/.oh-my-zsh" ]`) to avoid redundant operations
+3. **Configuration Path Resolution**: Use
+   `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` to locate
+   scripts, then reference shared config files via relative paths like
+   `$SCRIPT_DIR/../../config/shell`
+4. **Silent Installation**: Use appropriate flags (`--noconfirm` for pacman,
+   `-y` for apt/dnf, `RUNZSH=no KEEPZSHRC=yes` for the oh-my-zsh installer) to
+   avoid interactive prompts
 
 ### Key Installation Flow
 
 **Arch Linux** (`linux/arch/install-zsh-arch.sh`):
+
 - Installs base tools via pacman (zsh, git, unzip, zip, wget, base-devel)
-- Installs yay (AUR helper) if missing
+- Installs yay (AUR helper) from source if missing
 - Installs Starship prompt via yay
 - Installs Oh My Zsh framework
-- Clones zsh plugins (autosuggestions, syntax-highlighting) to `~/.oh-my-zsh/custom/plugins/`
-- Downloads and installs Hack Nerd Font v3.2.1 to `~/.local/share/fonts`
+- Clones zsh plugins (autosuggestions, syntax-highlighting) to
+  `~/.oh-my-zsh/custom/plugins/`
+- Downloads and installs Hack Nerd Font to `~/.local/share/fonts`
 - Copies shared config files from `config/shell/` to home directory
 
 **Ubuntu** (`linux/ubuntu/install-zsh-ubuntu.sh`):
+
 - Similar flow but uses apt instead of pacman
 - Uses curl for Starship installation instead of yay
 - Uses wget for Oh My Zsh installation
 
-**Arch Additional Tools** (`linux/arch/config-shell-tools-arch.sh`):
-- Installs packages from `pkglist.txt` via pacman
+**Fedora** (`linux/fedora/setup.sh`):
+
+- Single entry point running `install-zsh-fedora.sh` (shell foundation) then
+  `config-shell-tools-fedora.sh` (dev tools, apps, 1Password CLI, vault backup)
+- `install-infra-fedora.sh` is optional/opt-in (kubectl, k9s, flux, helm,
+  kustomize) and deliberately NOT run by `setup.sh`
+- `check-dotfiles.sh` audits deployed dotfiles/tools against the repo and
+  offers interactive fixes
+
+**Additional Tools** (`config-shell-tools-{arch,ubuntu,fedora}.sh`):
+
+- Installs packages from the distro's `pkglist.txt`
 - Clones LazyVim starter config to `~/.config/nvim`
-- Installs nvm and Node.js 22
+- Installs nvm and Node.js 24 (current LTS)
 - Installs Copilot.vim to `~/.config/nvim/pack/github/start/copilot.vim`
+- Installs the Obsidian CLI (`notesmd-cli`, formerly `obsidian-cli` — see
+  LEARNINGS.md) via `go install`
 
 ### Windows Script Architecture
 
-The PowerShell script (`windows/restore-windows-apps.ps1`) follows a different pattern:
+The PowerShell script (`windows/restore-windows-apps.ps1`) follows a different
+pattern:
+
 - Requires Administrator privileges
-- Uses both winget and Chocolatey package managers
+- Uses both winget and Chocolatey package managers, via
+  `Install-WingetApp`/`Install-ChocoPackage` helpers that check
+  `$LASTEXITCODE` (native commands don't throw PowerShell errors — try/catch
+  around them is dead code)
 - Enables Windows features via DISM (WSL, Virtual Machine Platform)
-- Installs applications via winget (Chrome, VSCode, Obsidian, Steam, Telegram, Ubuntu)
-- Installs applications via Chocolatey (Surfshark VPN, vcredist2019, Everything, Starship)
-- Checks installed Microsoft Store apps via `Get-AppxPackage` and installs missing ones
+- Installs applications via winget (Chrome, VSCode, Obsidian, Steam, Telegram,
+  Ubuntu)
+- Installs applications via Chocolatey (Surfshark VPN, vcredist140, Everything,
+  Starship)
+- Checks installed Microsoft Store apps via `Get-AppxPackage` and installs
+  missing ones
 
 ## Shell Configuration Details
 
 ### .zshrc Configuration
+
 Located in `config/shell/.zshrc`:
+
 - Enables extensive history management (10M entries) with deduplication
-- Plugins: git, sudo, history, encode64, copypath, kubectl, zsh-autosuggestions, zsh-syntax-highlighting
+- Adds `~/.zsh_functions` to `fpath` for custom completions — this MUST stay
+  before the `source $ZSH/oh-my-zsh.sh` line (compinit runs there; completions
+  added to fpath afterwards never register)
+- Plugins: git, sudo, history, encode64, copypath, kubectl,
+  zsh-autosuggestions, zsh-syntax-highlighting
 - Tool aliases: `cd=z` (zoxide), `cat=bat`, `lg=lazygit`, `vim=nvim`
 - Custom functions: `y()` for yazi file manager with directory changing
-- Integrations: starship prompt, zoxide, fzf
+- Integrations: starship prompt, direnv, fzf, zoxide (init kept last)
 
 ### Starship Configuration
+
 Located in `config/shell/starship.toml`:
+
 - Uses Nerd Font symbols for various language and tool indicators
 - Kubernetes integration enabled
 - Custom git branch styling (#ffcce1)
@@ -80,6 +129,7 @@ Located in `config/shell/starship.toml`:
 ## Development Commands
 
 ### Testing Linux Scripts
+
 ```bash
 # Arch Linux
 cd linux/arch
@@ -89,9 +139,16 @@ cd linux/arch
 # Ubuntu
 cd linux/ubuntu
 ./install-zsh-ubuntu.sh
+./config-shell-tools-ubuntu.sh
+./setup-tmux.sh
+
+# Fedora
+cd linux/fedora
+./setup.sh
 ```
 
 ### Testing Windows Script
+
 ```powershell
 # Run as Administrator
 cd windows
@@ -99,6 +156,7 @@ cd windows
 ```
 
 ### Checking Script Syntax
+
 ```bash
 # Bash scripts
 bash -n <script-name>.sh
@@ -111,26 +169,49 @@ pwsh -File <script-name>.ps1 -WhatIf
 
 ### When Modifying Scripts
 
-1. **Path Resolution**: Always use `SCRIPT_DIR` pattern to locate config files - never use hardcoded paths
-2. **Idempotency**: Scripts should be safe to run multiple times without breaking or duplicating installations
-3. **Silent Mode**: Keep all installations non-interactive for automation purposes
-4. **Error Handling**: Use conditional checks (`command -v`, `[ ! -d ]`, `[ ! -e ]`) before installations
-5. **Font Installation**: Hack Nerd Font v3.2.1 is the standard - URLs should point to this specific version
-6. **Plugin Paths**: Zsh plugins go to `${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/`
+1. **Path Resolution**: Always use `SCRIPT_DIR` pattern to locate config
+   files - never use hardcoded paths
+2. **Idempotency**: Scripts should be safe to run multiple times without
+   breaking or duplicating installations
+3. **Silent Mode**: Keep all installations non-interactive for automation
+   purposes
+4. **Error Handling**: Use conditional checks (`command -v`, `[ ! -d ]`,
+   `[ ! -e ]`) before installations
+5. **Font Installation**: Hack Nerd Font v3.4.0 is the standard - URLs should
+   point to this specific version
+6. **Plugin Paths**: Zsh plugins go to
+   `${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/`
 
 ### Configuration File Management
 
-The config files in `config/shell/` are shared across all Linux distributions. When modifying:
-- Test changes on both Arch and Ubuntu
-- Ensure tool-specific configurations (like zoxide, fzf) work when tools are installed
+The config files in `config/shell/` are shared across all Linux distributions.
+When modifying:
+
+- Test changes on both Arch and Ubuntu (and Fedora, the primary daily driver)
+- Ensure tool-specific configurations (like zoxide, fzf) work when tools are
+  installed
 - Keep aliases minimal and focused on common developer tools
 
 ### Package Management
 
 **Arch** (`linux/arch/pkglist.txt`):
+
 - Contains comprehensive system setup including GNOME desktop packages
-- Includes development tools: neovim, lazygit, tmux, bat, fd, fzf, ripgrep, yazi, zoxide
+- Official-repo packages ONLY — pacman aborts the entire transaction on any
+  unknown target, so AUR-only packages must never be listed here
+- Includes development tools: neovim, lazygit, tmux, bat, fd, fzf, ripgrep,
+  yazi, zoxide
 - System tools: btrfs-progs, snapper, zram-generator
 - ASUS-specific: asusctl, supergfxctl
 
-**Ubuntu**: No package list file - installs are handled in scripts only
+**Ubuntu** (`linux/ubuntu/pkglist.txt`):
+
+- Base build/dev tools (build-essential, cmake, golang-go) and CLI utilities;
+  the heavier tools (neovim, lazygit, yazi, ...) are installed from upstream
+  releases in `config-shell-tools-ubuntu.sh`
+
+**Fedora** (`linux/fedora/pkglist.txt`):
+
+- Dev/CLI tools only — Fedora KDE ships the base system and desktop, so the
+  list omits anything preinstalled (curl is deliberately excluded, see
+  LEARNINGS.md)

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -51,9 +51,12 @@ URL, module path, or package name).
 - **Obsidian has no native rpm** — install via Flatpak (`md.obsidian.Obsidian`),
   which is preinstalled on Fedora Workstation/KDE.
 - **zsh completions** live in `~/.zsh_functions/`, which `config/shell/.zshrc`
-  adds to `fpath` (look for the `fpath+=...zsh_functions` line). Dropping a
-  `_<tool>` file there is enough — oh-my-zsh runs `compinit`, no `.zshrc` edit
-  needed. If a new completion doesn't show up, clear the cache:
+  adds to `fpath`. The `fpath+=` line MUST come **before**
+  `source $ZSH/oh-my-zsh.sh` — oh-my-zsh runs `compinit` there, and completion
+  files in dirs added to `fpath` *after* compinit never register (verified:
+  `$_comps[flux]` stays empty while `_flux` sits in `~/.zsh_functions`).
+  With the ordering right, dropping a `_<tool>` file there is enough — no other
+  `.zshrc` edit needed. If a new completion doesn't show up, clear the cache:
   `rm -f ~/.zcompdump* && exec zsh`.
 - **`curl` is deliberately not in pkglist / `dnf install`** — listing it forces a
   swap from `curl-minimal` (shipped in `@core`) to full `curl`. See the comment
@@ -76,3 +79,37 @@ URL, module path, or package name).
     so `/releases/latest` may point at a non-kustomize component — filter for the
     `kustomize/vX.Y.Z` tag instead. The slash in that tag must be **URL-encoded
     (`%2F`)** in the download path.
+
+## Arch
+
+- **pacman aborts the ENTIRE transaction on any "target not found"** — one
+  AUR-only or removed package in `pkglist.txt` (e.g. `yay-bin`, `snapd`,
+  `neofetch`) means *nothing* installs. Keep the list official-repos-only and
+  verify names against `archlinux.org/packages`. Comments in the pkglist are
+  fine only because `config-shell-tools-arch.sh` greps them out before piping
+  to pacman.
+
+## Windows / PowerShell
+
+- **try/catch around `winget`/`choco` is dead code** — native executables never
+  throw PowerShell terminating errors on failure; they only set
+  `$LASTEXITCODE`. Every "Failed to install…" catch branch was unreachable.
+  Check `$LASTEXITCODE -ne 0` instead (see the `Install-WingetApp` /
+  `Install-ChocoPackage` helpers).
+- **Hashtable indexing doesn't happen in bare arguments**:
+  `winget install --id=$hash[$key]` passes the literal string
+  `--id=System.Collections.Hashtable[key]`. Wrap it: `$($hash[$key])`.
+
+## General
+
+- **Beware literal `\!` sneaking into scripts** — `setup-tmux.sh` was written
+  with escaped bangs (`#\!/bin/bash`, `if \! command -v tmux`), likely an
+  artifact of a shell's history-expansion escaping. The shebang silently breaks,
+  and `\!` is not the negation keyword: bash runs a command literally named `!`,
+  the test always fails, and the script reports "already installed" without
+  installing anything. `bash -n` does NOT catch this — grep for `\\!` after
+  writing scripts through any tool that escapes `!`.
+- **oh-my-zsh's installer execs into zsh at the end** unless `RUNZSH=no` is
+  set, halting the calling script mid-run until the user exits; it also
+  overwrites `~/.zshrc` unless `KEEPZSHRC=yes`. All three distros' install
+  scripts set both.

--- a/README.md
+++ b/README.md
@@ -4,49 +4,84 @@ This repository contains scripts and configuration files to quickly set up a wor
 
 ## Directory Structure
 
-```
+```text
 .
 ├── config/
-│   └── shell/
-│       ├── starship.toml    # Starship prompt configuration
-│       └── .zshrc          # Zsh shell configuration
+│   ├── backup/
+│   │   └── vault-backup.sh              # Encrypted Obsidian vault backup (rclone crypt)
+│   ├── shell/
+│   │   ├── .tmux.conf                   # Tmux configuration (TPM plugins)
+│   │   ├── .zshrc                       # Zsh shell configuration
+│   │   └── starship.toml                # Starship prompt configuration
+│   └── systemd/
+│       ├── vault-backup.service         # User unit for the vault backup
+│       └── vault-backup.timer           # Daily backup timer
 ├── linux/
 │   ├── arch/
 │   │   ├── config-shell-tools-arch.sh   # Additional shell tools setup
 │   │   ├── install-zsh-arch.sh          # Zsh installation for Arch
-│   │   └── pkglist.txt                  # Arch Linux package list
+│   │   └── pkglist.txt                  # Arch Linux package list (official repos only)
+│   ├── fedora/
+│   │   ├── setup.sh                     # Single entry point (runs the two below)
+│   │   ├── install-zsh-fedora.sh        # Shell foundation (zsh, OMZ, starship, font)
+│   │   ├── config-shell-tools-fedora.sh # Dev tools, apps, 1Password CLI, vault backup
+│   │   ├── install-infra-fedora.sh      # OPTIONAL: kubectl, k9s, flux, helm, kustomize
+│   │   ├── check-dotfiles.sh            # Audit dotfiles/tools, offer fixes
+│   │   └── pkglist.txt                  # Fedora package list
 │   └── ubuntu/
-│       └── install-zsh-ubuntu.sh        # Zsh installation for Ubuntu
-└── windows/
-    └── restore-windows-apps.ps1         # Windows apps restoration script
+│       ├── install-zsh-ubuntu.sh        # Zsh installation for Ubuntu
+│       ├── config-shell-tools-ubuntu.sh # Additional shell tools setup
+│       ├── setup-tmux.sh                # Tmux + TPM setup
+│       └── pkglist.txt                  # Ubuntu package list
+├── windows/
+│   └── restore-windows-apps.ps1         # Windows apps restoration script
+├── ACTIONS.md                           # Manual one-off setup notes
+└── LEARNINGS.md                         # Non-obvious gotchas — read before editing scripts
 ```
 
 ## Features
 
 ### Linux Setup
+
 #### Arch Linux
+
 - Complete Zsh environment setup with Oh My Zsh and Starship prompt
 - Additional development tools installation
 - Package installation from predefined list
 - Shell customization and configuration
 
+#### Fedora
+
+- Single-entry-point setup (`setup.sh`): shell foundation plus dev tools and apps
+- 1Password CLI (`op`) secrets workflow and direnv
+- Encrypted Obsidian vault backup (rclone crypt → Google Drive, systemd timer)
+- Optional opt-in infra tooling (kubectl, k9s, flux, helm, kustomize)
+- Dotfile/tool health check with interactive fixes (`check-dotfiles.sh`)
+
 #### Ubuntu
+
 - Zsh environment setup with Oh My Zsh and Starship prompt
+- Additional development tools installation (Neovim, LazyVim, nvm, lazygit, yazi, ...)
+- Tmux with plugin manager
 - Shell customization and configuration
 
 ### Windows Setup
+
 - Automated application restoration via Winget and Chocolatey
 - WSL setup and configuration
 - System features enablement
 - Development environment configuration
 
 ### Shell Configuration
+
 - Custom Zsh configuration with useful aliases and plugins
 - Starship prompt with custom styling and features
+- Tmux configuration with session persistence (resurrect + continuum)
 
 ## Usage
 
 1. Clone this repository:
+
    ```bash
    git clone <repository-url>
    cd workspace-setup
@@ -54,29 +89,38 @@ This repository contains scripts and configuration files to quickly set up a wor
 
 2. Choose the appropriate script for your operating system:
 
-   ### For Arch Linux:
+   ### For Arch Linux
+
    ```bash
    cd linux/arch
    ./install-zsh-arch.sh
    ./config-shell-tools-arch.sh
    ```
 
-   ### For Ubuntu:
-   ```bash
-   cd linux/ubuntu
-   ./install-zsh-ubuntu.sh
-   ```
+   ### For Fedora
 
-   ### For Fedora:
    ```bash
    cd linux/fedora
    ./setup.sh                    # shell foundation + dev tools & apps
 
-   # Optional — infra / Kubernetes tooling (kubectl, k9s, flux):
+   # Optional — infra / Kubernetes tooling (kubectl, k9s, flux, helm, kustomize):
    ./install-infra-fedora.sh
+
+   # Anytime — audit dotfiles and tools, with interactive fixes:
+   ./check-dotfiles.sh
    ```
 
-   ### For Windows:
+   ### For Ubuntu
+
+   ```bash
+   cd linux/ubuntu
+   ./install-zsh-ubuntu.sh
+   ./config-shell-tools-ubuntu.sh
+   ./setup-tmux.sh
+   ```
+
+   ### For Windows
+
    ```powershell
    cd windows
    .\restore-windows-apps.ps1
@@ -85,10 +129,12 @@ This repository contains scripts and configuration files to quickly set up a wor
 3. Configuration files are located in the `config` directory:
    - Copy `config/shell/.zshrc` to your home directory
    - Copy `config/shell/starship.toml` to `~/.config/starship.toml`
+   - Copy `config/shell/.tmux.conf` to your home directory
 
 ## Customization
 
 You can customize the configuration files according to your needs:
+
 - Edit `config/shell/.zshrc` for shell preferences
 - Modify `config/shell/starship.toml` for prompt customization
-- Update `linux/arch/pkglist.txt` to change the package selection for Arch Linux
+- Update `linux/<distro>/pkglist.txt` to change the package selection

--- a/config/agy/.agyrules
+++ b/config/agy/.agyrules
@@ -1,0 +1,7 @@
+# Docs Vault Location
+Whenever the user asks to "write to my docs", "read my docs", or mentions "my docs", always resolve this to the Obsidian vault directory at the following path:
+`~/Documents/obsidian`
+Do not ask for clarification about where the docs are located.
+
+# Communication & Command Execution
+Before running any commands or applying major changes, always explicitly narrate your reasoning and logic process to the user in your message. This allows the user to understand your plan, learn from it, or correct any assumptions before the action takes place.

--- a/config/backup/claude-config-backup.sh
+++ b/config/backup/claude-config-backup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Claude Code config backup: ~/.claude → Google Drive (rclone, UNENCRYPTED).
+#
+# ALLOWLIST, not denylist: only portable config is synced. This is the safety
+# mechanism for an unencrypted destination — a new secret file appearing in
+# ~/.claude can never be swept to Google Drive because it isn't on the list.
+# Deliberately EXCLUDED (secret / private / bulky): .credentials.json (OAuth
+# tokens), history.jsonl, sessions/, projects/ (conversation transcripts),
+# shell-snapshots/, remote-settings.json, policy-limits.json, settings.local.json.
+#
+# Plugins: back up the MANIFEST (installed_plugins.json + known_marketplaces.json)
+# — the declaration of what's installed — NOT the marketplaces/ and cache/ trees.
+# Those are large, churn daily, and are reproducible: a restore re-adds the
+# marketplaces and reinstalls from the manifest. User-authored customisation
+# lives in skills/ commands/ agents/ (top-level), which ARE backed up in full.
+#
+# Named [gdrive] remote (NOT an inline ":path:" connection string — that parses
+# to a LOCAL ./gdrive dir; see vault-backup.sh / LEARNINGS.md rclone colon trap).
+set -euo pipefail
+
+SRC="$HOME/.claude"
+
+# `sync` mirrors (a clean restore image); the dedicated destination path plus
+# the include-only filter mean it can only ever touch allowlisted config.
+exec rclone sync "$SRC" "gdrive:claude-config" \
+  --include "/CLAUDE.md" \
+  --include "/settings.json" \
+  --include "/skills/**" \
+  --include "/commands/**" \
+  --include "/agents/**" \
+  --include "/plugins/installed_plugins.json" \
+  --include "/plugins/known_marketplaces.json" \
+  --create-empty-src-dirs \
+  --log-level NOTICE

--- a/config/backup/sync_agyrules.sh
+++ b/config/backup/sync_agyrules.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure rclone is available
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "Error: rclone is not installed or not in PATH."
+    exit 1
+fi
+
+# -L is required to follow the symlink created in the setup script
+rclone copy -L "$HOME/.agyrules" gdrive:backups/

--- a/config/shell/.zshrc
+++ b/config/shell/.zshrc
@@ -1,6 +1,6 @@
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
-alias repo='cd ~/repo'
+alias repo='cd ~/repos'
 alias k=kubectl
 #HISTFILESIZE
 HISTFILE="$HOME/.zsh_history"
@@ -99,6 +99,11 @@ plugins=(
     zsh-syntax-highlighting
 )
 
+# Custom completions (_<tool> files). MUST be on fpath BEFORE oh-my-zsh.sh is
+# sourced — it runs compinit, and completions added to fpath after compinit
+# never register.
+fpath+=${ZDOTDIR:-~}/.zsh_functions
+
 source $ZSH/oh-my-zsh.sh
 
 # User configuration
@@ -130,7 +135,6 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 eval "$(starship init zsh)"
-fpath+=${ZDOTDIR:-~}/.zsh_functions
 # yazi script
 function y() {
 	local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd

--- a/config/systemd/agy-backup.service
+++ b/config/systemd/agy-backup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Antigravity Rules Backup
+
+[Service]
+Type=oneshot
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin
+ExecStart=%h/.local/bin/sync_agyrules.sh

--- a/config/systemd/agy-backup.timer
+++ b/config/systemd/agy-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily backup of Antigravity rules
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/config/systemd/claude-config-backup.service
+++ b/config/systemd/claude-config-backup.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Claude Code config backup to Google Drive (rclone, unencrypted allowlist)
+
+[Service]
+Type=oneshot
+# PATH so systemd finds rclone in ~/.local/bin (cron would not — see LEARNINGS.md).
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin
+ExecStart=%h/.local/bin/claude-config-backup.sh

--- a/config/systemd/claude-config-backup.timer
+++ b/config/systemd/claude-config-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Claude Code config backup
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/linux/arch/config-shell-tools-arch.sh
+++ b/linux/arch/config-shell-tools-arch.sh
@@ -3,16 +3,20 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Install packages (github-cli, obsidian, bitwarden-cli, go included via pkglist)
-sudo pacman -S --needed --noconfirm - < "$SCRIPT_DIR/pkglist.txt"
+grep -vE '^\s*#|^\s*$' "$SCRIPT_DIR/pkglist.txt" | sudo pacman -S --needed --noconfirm -
 
 git clone https://github.com/LazyVim/starter ~/.config/nvim || true
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash || true
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash || true
 
 git clone https://github.com/github/copilot.vim.git \
   ~/.config/nvim/pack/github/start/copilot.vim || true
 
 . "$HOME/.nvm/nvm.sh" || true
-nvm install 22 || true
+nvm install 24 || true
 
-# Obsidian CLI (Yakitrak) — built with go, lands in ~/go/bin
-go install github.com/Yakitrak/obsidian-cli@latest || true
+# Obsidian CLI — upstream renamed obsidian-cli → notesmd-cli (see LEARNINGS.md).
+# Built with go, lands in ~/go/bin as `notesmd-cli`.
+go install github.com/Yakitrak/notesmd-cli@latest || true
+
+echo ":: Antigravity setup"
+bash "$SCRIPT_DIR/../config-agy.sh"

--- a/linux/arch/install-zsh-arch.sh
+++ b/linux/arch/install-zsh-arch.sh
@@ -4,7 +4,8 @@
 sudo -v
 
 # Install necessary packages silently
-sudo pacman -Sy --needed --noconfirm zsh git unzip zip wget base-devel
+# -Syu (not -Sy): installing after a partial database sync can break the system
+sudo pacman -Syu --needed --noconfirm zsh git unzip zip wget base-devel
 
 # Install yay if not installed
 if ! command -v yay &> /dev/null; then
@@ -18,14 +19,13 @@ fi
 if ! command -v starship &> /dev/null; then
     echo "Installing Starship..."
     yay -S --needed --noconfirm --removemake --mflags "--nocheck" starship
-    mkdir -p $HOME/.config
-    starship preset nerd-font-symbols -o $HOME/.config/starship.toml
 else
     echo "Starship is already installed"
 fi
 
-# Install Oh My Zsh
-[ ! -d "$HOME/.oh-my-zsh" ] && sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+# Install Oh My Zsh (RUNZSH=no: the installer otherwise execs into zsh and
+# halts this script; KEEPZSHRC=yes: don't clobber .zshrc — we copy our own below)
+[ ! -d "$HOME/.oh-my-zsh" ] && RUNZSH=no KEEPZSHRC=yes sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # Set Zsh as default shell
 if [ "$SHELL" != "/usr/bin/zsh" ]; then
@@ -40,7 +40,7 @@ ZSH_CUSTOM=${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}
 # Install Hack Nerd Font
 if ! fc-list | grep -qi 'Hack Nerd Font'; then
     echo "Installing Hack Nerd Font..."
-    wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Hack.zip -O /tmp/Hack.zip
+    wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip -O /tmp/Hack.zip
     mkdir -p $HOME/.local/share/fonts
     unzip /tmp/Hack.zip -d $HOME/.local/share/fonts
     rm /tmp/Hack.zip

--- a/linux/arch/pkglist.txt
+++ b/linux/arch/pkglist.txt
@@ -1,3 +1,6 @@
+# Official-repo packages ONLY. pacman aborts the ENTIRE transaction on any
+# "target not found", so AUR-only packages (yay-bin, snapd, ...) must never be
+# listed here — yay itself is built from the AUR by install-zsh-arch.sh.
 7zip
 amd-ucode
 asusctl
@@ -13,6 +16,7 @@ dosfstools
 efibootmgr
 epiphany
 evince
+fastfetch
 fd
 firefox
 fzf
@@ -74,7 +78,6 @@ loupe
 luarocks
 malcontent
 nautilus
-neofetch
 neovim
 networkmanager
 obsidian
@@ -87,7 +90,6 @@ pipewire-pulse
 ripgrep
 rygel
 simple-scan
-snapd
 snapper
 snapshot
 sof-firmware
@@ -104,8 +106,6 @@ wireplumber
 xclip
 xdg-desktop-portal-gnome
 xdg-user-dirs-gtk
-yay-bin
-yay-bin-debug
 yazi
 yelp
 zip

--- a/linux/config-agy.sh
+++ b/linux/config-agy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Antigravity tooling and backup setup
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$SCRIPT_DIR/../config"
+
+# Ensure ~/.local/bin exists
+mkdir -p "$HOME/.local/bin"
+
+# Symlink .agyrules
+ln -sf "$CONFIG_DIR/agy/.agyrules" "$HOME/.agyrules"
+
+# Symlink sync script
+ln -sf "$CONFIG_DIR/backup/sync_agyrules.sh" "$HOME/.local/bin/sync_agyrules.sh"
+chmod +x "$HOME/.local/bin/sync_agyrules.sh"
+
+# Setup systemd timer
+mkdir -p "$HOME/.config/systemd/user"
+cp "$CONFIG_DIR/systemd/agy-backup.service" "$CONFIG_DIR/systemd/agy-backup.timer" "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+
+echo "  Antigravity setup complete."
+echo "  Note: The backup requires the 'gdrive:' rclone remote to be configured."
+echo "  Once rclone is authenticated, enable the backup timer with:"
+echo "  systemctl --user enable --now agy-backup.timer"

--- a/linux/fedora/check-dotfiles.sh
+++ b/linux/fedora/check-dotfiles.sh
@@ -66,8 +66,21 @@ check_tool "lazygit"   "lazygit"   "see config-shell-tools-fedora.sh"
 check_tool "yazi"      "yazi"      "see config-shell-tools-fedora.sh"
 check_tool "fzf"       "fzf"       "git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && ~/.fzf/install"
 check_tool "gh"        "GitHub CLI" "sudo dnf install -y gh"
-check_tool "bw"        "Bitwarden CLI" "npm install -g @bitwarden/cli"
-check_tool "obsidian-cli" "obsidian-cli" "go install github.com/Yakitrak/obsidian-cli@latest"
+check_tool "tmux"      "tmux"      "sudo dnf install -y tmux"
+check_tool "op"        "1Password CLI" "see config-shell-tools-fedora.sh (1Password dnf repo)"
+check_tool "direnv"    "direnv"    "sudo dnf install -y direnv"
+check_tool "rclone"    "rclone"    "sudo dnf install -y rclone"
+
+# Obsidian CLI was renamed upstream to notesmd-cli (see LEARNINGS.md); it lands
+# in ~/go/bin, which may not be on this (bash) shell's PATH — check both.
+if ! command -v notesmd-cli &>/dev/null && [ ! -x "$HOME/go/bin/notesmd-cli" ]; then
+  flag "tool" "${RED}MISSING${NC}    tool: notesmd-cli (obsidian CLI)" "go install github.com/Yakitrak/notesmd-cli@latest"
+fi
+
+# tmux plugin manager
+if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
+  flag "plugin" "${RED}MISSING${NC}    tmux plugin manager (tpm)" "https://github.com/tmux-plugins/tpm|$HOME/.tmux/plugins/tpm"
+fi
 
 # fzf shell integration (.fzf.zsh must exist for .zshrc to source it)
 if command -v fzf &>/dev/null && [ ! -f "$HOME/.fzf.zsh" ]; then

--- a/linux/fedora/config-shell-tools-fedora.sh
+++ b/linux/fedora/config-shell-tools-fedora.sh
@@ -26,11 +26,11 @@ fi
 step "tmux plugin manager"
 [ -d "$HOME/.tmux/plugins/tpm" ] || git clone -q https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 
-step "nvm + Node 22"
-[ -d "$HOME/.nvm" ] || curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash >/dev/null
+step "nvm + Node 24"
+[ -d "$HOME/.nvm" ] || curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash >/dev/null
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm list 2>/dev/null | grep -q "v22" || nvm install 22 >/dev/null
+nvm list 2>/dev/null | grep -q "v24" || nvm install 24 >/dev/null
 
 step "fzf"
 [ -d "$HOME/.fzf" ] || { git clone -q --depth 1 https://github.com/junegunn/fzf.git ~/.fzf; ~/.fzf/install --all --no-bash --no-fish >/dev/null; }
@@ -99,3 +99,18 @@ systemctl --user daemon-reload
 echo "  Once per machine (interactive): follow the restore guide in the 1Password"
 echo "  item 'obsidian-vault-backup' (rclone gdrive OAuth + gdrive-crypt remote),"
 echo "  then: systemctl --user enable --now vault-backup.timer"
+
+step "Claude Code config backup (rclone → Google Drive, UNENCRYPTED)"
+# Daily backup of portable ~/.claude config (CLAUDE.md, settings.json, plugins/,
+# skills/, commands/, agents/) via an ALLOWLIST — secrets and private history
+# (.credentials.json, sessions/, projects/, history.jsonl) are never in scope.
+# Reuses the same plain [gdrive] remote the vault OAuth sets up (above).
+install -D "$SCRIPT_DIR/../../config/backup/claude-config-backup.sh" "$HOME/.local/bin/claude-config-backup.sh"
+cp "$SCRIPT_DIR/../../config/systemd/claude-config-backup.service" \
+   "$SCRIPT_DIR/../../config/systemd/claude-config-backup.timer" "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+echo "  After the gdrive remote exists (see vault backup above):"
+echo "  systemctl --user enable --now claude-config-backup.timer"
+
+step "Antigravity setup"
+bash "$SCRIPT_DIR/../config-agy.sh"

--- a/linux/fedora/install-zsh-fedora.sh
+++ b/linux/fedora/install-zsh-fedora.sh
@@ -32,7 +32,7 @@ command -v starship >/dev/null || curl -sS https://starship.rs/install.sh | sh -
 
 step "Hack Nerd Font"
 if ! fc-list | grep -qi 'Hack Nerd Font'; then
-  curl -fsSL https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Hack.zip -o /tmp/Hack.zip
+  curl -fsSL https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip -o /tmp/Hack.zip
   mkdir -p "$HOME/.local/share/fonts"
   unzip -oq /tmp/Hack.zip -d "$HOME/.local/share/fonts"
   rm -f /tmp/Hack.zip

--- a/linux/ubuntu/config-shell-tools-ubuntu.sh
+++ b/linux/ubuntu/config-shell-tools-ubuntu.sh
@@ -49,7 +49,7 @@ fi
 # Install nvm
 if [ ! -d "$HOME/.nvm" ]; then
     echo "Installing nvm..."
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
 else
     echo "nvm is already installed"
 fi
@@ -68,12 +68,12 @@ if [ -d "$HOME/.nvm" ]; then
     export NVM_DIR="$HOME/.nvm"
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-    # Check if Node.js 22 is installed
-    if ! nvm list | grep -q "v22"; then
-        echo "Installing Node.js 22..."
-        nvm install 22
+    # Check if Node.js 24 (current LTS) is installed
+    if ! nvm list | grep -q "v24"; then
+        echo "Installing Node.js 24..."
+        nvm install 24
     else
-        echo "Node.js 22 is already installed"
+        echo "Node.js 24 is already installed"
     fi
 fi
 
@@ -145,10 +145,11 @@ else
     echo "Obsidian is already installed"
 fi
 
-# Install Obsidian CLI (Yakitrak) via go; lands in ~/go/bin
-if [ ! -x "$HOME/go/bin/obsidian-cli" ]; then
-    echo "Installing Obsidian CLI..."
-    go install github.com/Yakitrak/obsidian-cli@latest
+# Install Obsidian CLI — upstream renamed obsidian-cli → notesmd-cli (see
+# LEARNINGS.md); built with go, lands in ~/go/bin as `notesmd-cli`
+if [ ! -x "$HOME/go/bin/notesmd-cli" ]; then
+    echo "Installing Obsidian CLI (notesmd-cli)..."
+    go install github.com/Yakitrak/notesmd-cli@latest
 else
     echo "Obsidian CLI is already installed"
 fi
@@ -160,3 +161,6 @@ if ! command -v bw &> /dev/null; then
 else
     echo "Bitwarden CLI is already installed"
 fi
+
+echo "Installing Antigravity tooling and backups..."
+bash "$SCRIPT_DIR/../config-agy.sh"

--- a/linux/ubuntu/install-zsh-ubuntu.sh
+++ b/linux/ubuntu/install-zsh-ubuntu.sh
@@ -5,20 +5,20 @@
 #Install zsh
 command -v zsh &>/dev/null || sudo apt install zsh -y
 
-#Install oh-my-zsh
-[ ! -d "$HOME/.oh-my-zsh" ] && sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+#Install oh-my-zsh (RUNZSH=no: the installer otherwise execs into zsh and
+#halts this script; KEEPZSHRC=yes: don't clobber .zshrc — we copy our own below)
+[ ! -d "$HOME/.oh-my-zsh" ] && RUNZSH=no KEEPZSHRC=yes sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 #Set zsh as a default
-[ $SHELL != "/usr/bin/zsh" ] && chsh -s $(which zsh)
+[ "$SHELL" != "/usr/bin/zsh" ] && chsh -s "$(which zsh)"
 
 #Install necessary plugins
 [ ! -e "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" ] && git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 [ ! -e "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" ] && git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 
-#Check if starship is installed, probably needs review
+#Check if starship is installed
 if ! command -v starship &>/dev/null; then
   curl -sS https://starship.rs/install.sh | sh -s -- -y
-  starship preset nerd-font-symbols -o $HOME/.config/starship.toml
 else
   echo 'Starship is already installed'
 fi
@@ -27,13 +27,13 @@ command -v zip &>/dev/null || sudo apt install zip -y
 
 #Install Hack Nerd Font
 if ! fc-list | grep -qi 'Hack Nerd Font'; then
-  wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Hack.zip
+  wget https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/Hack.zip -O /tmp/Hack.zip
   mkdir -p $HOME/.local/share/fonts
-  unzip Hack.zip -d $HOME/.local/share/fonts
-  rm Hack.zip
+  unzip /tmp/Hack.zip -d $HOME/.local/share/fonts
+  rm /tmp/Hack.zip
   fc-cache -fv
 else
-  echo 'Hack font already isntalled'
+  echo 'Hack font already installed'
 fi
 
 #Copy config files

--- a/linux/ubuntu/pkglist.txt
+++ b/linux/ubuntu/pkglist.txt
@@ -16,5 +16,5 @@ btrfs-progs
 snapd
 luarocks
 golang-go
-neofetch
+fastfetch
 fontconfig

--- a/linux/ubuntu/setup-tmux.sh
+++ b/linux/ubuntu/setup-tmux.sh
@@ -1,11 +1,11 @@
-#\!/bin/bash
+#!/bin/bash
 
 # Get script directory for relative path resolution
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="$SCRIPT_DIR/../../config/shell"
 
 # Install tmux if not already installed
-if \! command -v tmux &> /dev/null; then
+if ! command -v tmux &> /dev/null; then
     echo "Installing tmux..."
     sudo apt update
     sudo apt install -y tmux
@@ -14,7 +14,7 @@ else
 fi
 
 # Install TPM (Tmux Plugin Manager)
-if [ \! -d "$HOME/.tmux/plugins/tpm" ]; then
+if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
     echo "Installing Tmux Plugin Manager..."
     git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 else
@@ -31,6 +31,6 @@ else
 fi
 
 echo ""
-echo "Tmux setup complete\!"
+echo "Tmux setup complete!"
 echo "To install tmux plugins, start tmux and press: prefix + I (capital i)"
 echo "Default prefix is Ctrl+b"

--- a/windows/restore-windows-apps.ps1
+++ b/windows/restore-windows-apps.ps1
@@ -38,6 +38,25 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     exit 1
 }
 
+# --- Helpers ---
+# winget/choco are native executables: they never throw PowerShell terminating
+# errors on failure, so try/catch around them is dead code — check $LASTEXITCODE.
+function Install-WingetApp {
+    param([string]$Id)
+    winget install -e --id $Id -h --accept-source-agreements --accept-package-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to install $Id via winget (exit code $LASTEXITCODE). Install it manually."
+    }
+}
+
+function Install-ChocoPackage {
+    param([string]$Name)
+    choco install $Name -y
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to install $Name via Chocolatey (exit code $LASTEXITCODE)."
+    }
+}
+
 # --- Check for Chocolatey ---
 if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
     Write-Output "Chocolatey not found. Installing Chocolatey..."
@@ -64,66 +83,29 @@ dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /nores
 
 # --- Install Ubuntu via winget ---
 Write-Output "Installing Ubuntu for WSL..."
-try {
-    winget install -e --id=Canonical.Ubuntu -h
-} catch {
-    Write-Output "Failed to install Ubuntu via winget. Please install it manually from the Microsoft Store."
-}
+Install-WingetApp Canonical.Ubuntu
 
 # --- Install basic applications using winget ---
 Write-Output "Installing basic applications via winget..."
-
-# Google Chrome
-try {
-    winget install -e --id=Google.Chrome -h
-} catch {
-    Write-Output "Failed to install Google Chrome via winget."
-}
-
-# Visual Studio Code
-try {
-    winget install -e --id=Microsoft.VisualStudioCode -h
-} catch {
-    Write-Output "Failed to install Visual Studio Code via winget."
-}
-
-# Obsidian (adjust the package ID if necessary)
-try {
-    winget install -e --id=Obsidian.Obsidian -h
-} catch {
-    Write-Output "Failed to install Obsidian via winget."
-}
-
-# Steam
-try {
-    winget install -e --id=Valve.Steam -h
-} catch {
-    Write-Output "Failed to install Steam via winget."
-}
-
-# Telegram Desktop
-try {
-    winget install -e --id=Telegram.TelegramDesktop -h
-} catch {
-    Write-Output "Failed to install Telegram Desktop via winget."
+$wingetApps = @(
+    "Google.Chrome",
+    "Microsoft.VisualStudioCode",
+    "Obsidian.Obsidian",
+    "Valve.Steam",
+    "Telegram.TelegramDesktop"
+)
+foreach ($app in $wingetApps) {
+    Install-WingetApp $app
 }
 
 # --- Install Surfshark VPN via Chocolatey ---
 Write-Output "Installing Surfshark VPN via Chocolatey..."
-try {
-    # Adjust package name if needed (commonly "surfshark-vpn")
-    choco install surfshark-vpn -y
-} catch {
-    Write-Output "Failed to install Surfshark VPN via Chocolatey."
-}
+Install-ChocoPackage surfshark-vpn
 
 # --- Install Visual C++ Redistributable ---
-Write-Output "Installing Visual C++ Redistributable (2019) via Chocolatey..."
-try {
-    choco install vcredist2019 -y
-} catch {
-    Write-Output "Failed to install Visual C++ Redistributable."
-}
+# vcredist140 is the unified 2015-2022 redistributable (supersedes vcredist2019).
+Write-Output "Installing Visual C++ Redistributable (2015-2022) via Chocolatey..."
+Install-ChocoPackage vcredist140
 
 # --- Install additional Chocolatey packages ---
 Write-Output "Installing additional Chocolatey packages..."
@@ -141,30 +123,18 @@ $chocoPackages = @(
 )
 
 foreach ($pkg in $chocoPackages) {
-    try {
-        choco install $pkg -y
-    } catch {
-        Write-Output "Failed to install $pkg via Chocolatey."
-    }
+    Install-ChocoPackage $pkg
 }
 
 # --- Update AMD Drivers ---
 Write-Output "Attempting to update AMD drivers via winget..."
-try {
-    # Replace the package ID below with the correct one if necessary.
-    winget install -e --id=AMD.RadeonSoftware -h
-} catch {
-    Write-Output "AMD driver package not available via winget. Please update AMD drivers manually."
-}
+# Replace the package ID below with the correct one if necessary.
+Install-WingetApp AMD.RadeonSoftware
 
 # --- Attempt to install MS Office Home ---
 Write-Output "Attempting to install MS Office Home..."
-try {
-    # MS Office Home/Student is often not available as an automated install via winget/choco.
-    winget install -e --id=Microsoft.Office.Home -h
-} catch {
-    Write-Output "MS Office Home is not available via winget. Please install it manually."
-}
+# MS Office Home/Student is often not available as an automated install via winget/choco.
+Install-WingetApp Microsoft.Office.Home
 
 # --- Ensure non-default Microsoft Store apps are installed ---
 Write-Output "Ensuring non-default Microsoft Store apps are installed..."
@@ -175,7 +145,9 @@ Write-Output "Ensuring non-default Microsoft Store apps are installed..."
 $msAppsToInstall = @{
     "OpenAI.ChatGPT-Desktop"           = "OpenAI.ChatGPT-Desktop"
     "Microsoft.MicrosoftOfficeHub"       = "Microsoft.MicrosoftOfficeHub"
-    "MicrosoftTeams"                     = "MicrosoftTeams"
+    # New Teams: Appx name is MSTeams, winget ID Microsoft.Teams (classic
+    # "MicrosoftTeams" is retired)
+    "MSTeams"                            = "Microsoft.Teams"
     "5319275A.WhatsAppDesktop"           = "5319275A.WhatsAppDesktop"
     "Microsoft.OutlookForWindows"        = "Microsoft.OutlookForWindows"
     "Microsoft.PowerAutomateDesktop"     = "Microsoft.PowerAutomateDesktop"
@@ -195,11 +167,9 @@ foreach ($app in $msAppsToInstall.Keys) {
         Write-Output "$app is already installed."
     } else {
         Write-Output "$app is not installed. Attempting installation via winget..."
-        try {
-            winget install -e --id=$msAppsToInstall[$app] -h
-        } catch {
-            Write-Output "Failed to install $app via winget. Please install it manually from the Microsoft Store."
-        }
+        # $(...) is required: bare "$hash[$key]" in an argument expands the hash
+        # to its type name and appends "[key]" literally.
+        Install-WingetApp $($msAppsToInstall[$app])
     }
 }
 


### PR DESCRIPTION
Antigravity (`agy`) CLI setup, two rclone→Google Drive config backups, and the shell-script hardening from the same pass. Reviewed + verified end-to-end.

## Antigravity
- `linux/config-agy.sh` — symlinks `.agyrules`, installs the backup as a **systemd user timer** (not cron), documents the `gdrive:` remote prereq; wired into all three distros.
- `.gemini/settings.json` — pinned community Google MCP `@pegasusheavy/google-mcp@1.0.2` (no official Google MCP exists for consumer Workspace data).

## Backups (systemd user timers, `Persistent=true`, `Environment=PATH` so rclone resolves)
- `sync_agyrules.sh` — `rclone copy -L` (follows the symlink) + `set -euo pipefail` + rclone guard.
- `claude-config-backup.sh` — UNENCRYPTED `~/.claude` backup via an **allowlist** (`CLAUDE.md`, `settings.json`, `skills/`/`commands/`/`agents/`, plugin manifest); deliberately excludes `.credentials.json`, `history.jsonl`, `sessions/`, `projects/`, and the reproducible plugin cache/marketplaces trees.

## Shell fixes
`.zshrc` `fpath+=` before compinit; `repo`→`~/repos`; oh-my-zsh `RUNZSH=no KEEPZSHRC=yes`; Bitwarden→1Password; `obsidian-cli`→`notesmd-cli`; Node 24 / nvm 0.40.5 / Hack font 3.4.0.

## Verification
- `bash -n` clean on all 6 scripts.
- **agy backup runs end-to-end** — `agy-backup.service` → `Result=success`, `.agyrules` confirmed on `gdrive:backups/`.
- claude-config backup synced (4.5 KiB on Drive; zero secrets — allowlist verified against `~/.claude`).
- Secret scan of the whole change set: no credential values (only 1Password item-name references + exclusion-describing comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)